### PR TITLE
Fix: Error: Can't resolve 'styles/ganttElastic.css'

### DIFF
--- a/src/GanttElastic.vue
+++ b/src/GanttElastic.vue
@@ -1298,5 +1298,5 @@ export default GanttElastic;
 </script>
 
 <style>
-@import "styles/ganttElastic.css";
+@import url("./styles/ganttElastic.css");
 </style>


### PR DESCRIPTION
I found a bug When using from nuxt.

```
Module build failed (from ./node_modules/postcss-loader/src/index.js):
Error: Can't resolve 'styles/ganttElastic.css' in '/Users/yas/work/cup-gantt/node_modules/gantt-elastic/src'
```