### PR TITLE
Fixed event bubbling when setting scrollLeft for chartScrollContainerHorizontal in scrollTime

### DIFF
--- a/src/GanttElastic.vue
+++ b/src/GanttElastic.vue
@@ -9,7 +9,7 @@
 <template>
   <div class="gantt-elastic" style="width:100%">
     <slot name="header"></slot>
-    <main-view></main-view>
+    <main-view ref="mainView"></main-view>
     <slot name="footer"></slot>
   </div>
 </template>
@@ -979,7 +979,7 @@ const GanttElastic = {
       if (left !== null) {
         this.state.refs.chartCalendarContainer.scrollLeft = left;
         this.state.refs.chartGraphContainer.scrollLeft = left;
-        this.state.refs.chartScrollContainerHorizontal.setScrollLeft(left);
+        this.$refs.mainView.setScrollLeft(left);
         this.state.options.scroll.left = left;
       }
       if (top !== null) {

--- a/src/GanttElastic.vue
+++ b/src/GanttElastic.vue
@@ -979,7 +979,7 @@ const GanttElastic = {
       if (left !== null) {
         this.state.refs.chartCalendarContainer.scrollLeft = left;
         this.state.refs.chartGraphContainer.scrollLeft = left;
-        this.state.refs.chartScrollContainerHorizontal.scrollLeft = left;
+        this.state.refs.chartScrollContainerHorizontal.setScrollLeft(left);
         this.state.options.scroll.left = left;
       }
       if (top !== null) {

--- a/src/components/MainView.vue
+++ b/src/components/MainView.vue
@@ -93,6 +93,8 @@
 import TaskList from './TaskList/TaskList.vue';
 import Chart from './Chart/Chart.vue';
 
+let ignoreScrollEvents = false;
+
 export default {
   name: 'MainView',
   components: {
@@ -174,6 +176,14 @@ export default {
   },
   methods: {
     /**
+     * set scrollLeft and prevent event bubbling
+     */
+    setScrollLeft(left) {
+      ignoreScrollEvents  = true;
+      this.$refs.chartScrollContainerHorizontal.scrollLeft = left;
+    },
+
+    /**
      * Emit event when mouse is moving inside main view
      */
     mouseMove(event) {
@@ -191,6 +201,9 @@ export default {
      * Horizontal scroll event handler
      */
     onHorizontalScroll(ev) {
+      let ignore = ignoreScrollEvents;
+      ignoreScrollEvents = false;
+      if (ignore) return;
       this.root.$emit('chart-scroll-horizontal', ev);
     },
 


### PR DESCRIPTION
Setting scrollLeft in scrollTime on load leads to an emit of onHorizontalScroll event which leads to layout because getting .scrollLeft value (please read Paul Irish https://gist.github.com/paulirish/5d52fb081b3570c81e3a for detailed information).
![Schnappschuss_051719_115546_PM](https://user-images.githubusercontent.com/10764520/57958790-52a53e00-7901-11e9-9a03-b448be98c0da.jpg)
![Schnappschuss_051719_104330_PM](https://user-images.githubusercontent.com/10764520/57958793-546f0180-7901-11e9-9a70-f73c3b52b45b.jpg)
