### PR TITLE
Each dependency line can be styled individually

### DIFF
--- a/src/components/Chart/DependencyLines.vue
+++ b/src/components/Chart/DependencyLines.vue
@@ -18,7 +18,7 @@
     <g v-for="task in dependencyTasks" :key="task.id" :task="task">
       <path
         class="gantt-elastic__chart-dependency-lines-path"
-        :style="{ ...root.style['chart-dependency-lines-path'], ...task.style['chart-dependency-lines-path'] }"
+        :style="{ ...root.style['chart-dependency-lines-path'], ...task.style['chart-dependency-lines-path'], ...task.style['chart-dependency-lines-path-' + dependencyLine.task_id] }"
         v-for="dependencyLine in task.dependencyLines"
         :key="dependencyLine.id"
         :task="task"
@@ -108,7 +108,7 @@ export default {
         .filter(task => typeof task.dependentOn !== 'undefined')
         .map(task => {
           task.dependencyLines = task.dependentOn.map(id => {
-            return { points: this.getPoints(id, task.id) };
+            return { points: this.getPoints(id, task.id), task_id: id };
           });
           return task;
         })


### PR DESCRIPTION
This change will make each dependency line to be styled individually.

You can simply add a property referencing the id of the depending task:

```
let tasks = [
  {
    id: 1,
    type: 'task',
    label: 'Important task',
    dependentOn: [2, 3],
    style: {
      'chart-dependency-lines-path-2': {
        stroke: '#FF0000' // Turn the line from task 1 to task 2 red.
      }
    }
  },
  {
    id: 2,
    type: 'task',
    label: 'Do this first though'
  },
  {
    id: 3,
    type: 'task',
    label: 'This could maybe be done first, too'
  }
];
```

The use case:

When you want to highlight the successors and the predecessors of a task you can currently only hightlight all predecessors (depententOn) at once. But if you have a successor with multiple predecessors you must only highlight the line leading to the selected item, not other predecessors.
Example:

Only highlighting the path leading to the current item (one of the successors predecessors).
![grafik](https://user-images.githubusercontent.com/5699183/60341066-92a21b00-99ad-11e9-9d03-17bbe735245b.png)

Light blue: Mouseover
Green: All predecessors highlighted via dependsOn
Red: Filter all tasks by searching for the currently selected (mouseover) id each tasks dependentOn array. Notice how only the one relevant dependency line is highlighted.
