### PR TITLE
Add group task type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 .vscode/
 .sonarlint/
 node_modules/

--- a/src/GanttElastic.vue
+++ b/src/GanttElastic.vue
@@ -628,6 +628,14 @@ const GanttElastic = {
       });
       this.state.options = options;
       tasks = this.fillTasks(tasks);
+
+      tasks.forEach(task => {
+        if (task.tasks) {
+          this.mapTasks(task.tasks, options);
+          this.fillTasks(task.tasks);
+        }
+      });
+
       this.state.tasksById = this.resetTaskTree(tasks);
       this.state.taskTree = this.makeTaskTree(this.state.rootTask, tasks);
       this.state.tasks = this.state.taskTree.allChildren.map(childId => this.getTask(childId));
@@ -1432,6 +1440,22 @@ const GanttElastic = {
         task.y =
           (this.state.options.row.height + this.state.options.chart.grid.horizontal.gap * 2) * index +
           this.state.options.chart.grid.horizontal.gap;
+        if (task.tasks) {
+          const subtasks = [];
+          task.tasks.forEach(subtask => {
+            subtask.width =
+              subtask.duration / this.state.options.times.timePerPixel -
+              this.style['grid-line-vertical']['stroke-width'];
+            if (subtask.width < 0) {
+              subtask.width = 0;
+            }
+            subtask.height = task.height;
+            subtask.x = this.timeToPixelOffsetX(subtask.startTime);
+            subtask.y = task.y;
+            subtasks.push(subtask);
+          });
+          task.tasks = subtasks;
+        }
       }
       return visibleTasks;
     },

--- a/src/components/Chart/Chart.vue
+++ b/src/components/Chart/Chart.vue
@@ -76,6 +76,7 @@ import DependencyLines from './DependencyLines.vue';
 import Task from './Row/Task.vue';
 import Milestone from './Row/Milestone.vue';
 import Project from './Row/Project.vue';
+import Group from './Row/Group.vue';
 export default {
   name: 'Chart',
   components: {
@@ -85,6 +86,7 @@ export default {
     Task,
     Milestone,
     Project,
+    Group,
     DaysHighlight
   },
   inject: ['root'],

--- a/src/components/Chart/Row/Group.vue
+++ b/src/components/Chart/Row/Group.vue
@@ -2,7 +2,7 @@
 /**
  * @fileoverview Group component
  * @license MIT
- * @author Rafal Pospiech <neuronet.io@gmail.com>
+ * @author Gabriel Jimenez <gjimenez@nextdigital.es>
  * @package GanttElastic
  */
 -->

--- a/src/components/Chart/Row/Group.vue
+++ b/src/components/Chart/Row/Group.vue
@@ -1,0 +1,47 @@
+<!--
+/**
+ * @fileoverview Group component
+ * @license MIT
+ * @author Rafal Pospiech <neuronet.io@gmail.com>
+ * @package GanttElastic
+ */
+-->
+<template>
+  <g>
+    <component
+      v-for="subtask in subtaskList"
+      :task="subtask"
+      :key="subtask.id"
+      :is="subtask.type">
+    </component>
+  </g>
+</template>
+
+<script>
+import ChartText from '../Text.vue';
+import ProgressBar from '../ProgressBar.vue';
+import Expander from '../../Expander.vue';
+import taskMixin from './Task.mixin.js';
+import Task from 'gantt-elastic/src/components/Chart/Row/Task';
+import Milestone from 'gantt-elastic/src/components/Chart/Row/Milestone';
+import Project from 'gantt-elastic/src/components/Chart/Row/Project';
+export default {
+  name: 'Group',
+  components: {
+    Task,
+    Milestone,
+    Project,
+  },
+  inject: ['root'],
+  props: ['task'],
+  mixins: [taskMixin],
+  data() {
+    return {};
+  },
+  computed: {
+    subtaskList() {
+      return this.task.tasks;
+    },
+  },
+};
+</script>


### PR DESCRIPTION
Add 'Group' task type and component. A group has a 'task' property with task object array. See #17 

Example model:
```javascript
{
    id: 1,
    label: 'Make some noise',
    user:
        '<a href="https://www.google.com/search?q=John+Doe" target="_blank" style="color:#0077c0;">John Doe</a>',
    start: getDate(-24 * 5),
    duration: 15 * 24 * 60 * 60 * 1000,
    percent: 85,
    type: 'project',
  },
{
    id: 2,
    label: 'Group',
    user: '<a href="https://www.google.com/search?q=Clark+Kent" target="_blank" style="color:#0077c0;">Clark Kent</a>',
    start: getDate(-24 * 2),
    duration: 6 * 24 * 60 * 60 * 1000,
    percent: 25,
    type: 'group',
    tasks: [
      {
        id: 21,
        label: 'Group subtask 1',
        user: '<a href="https://www.google.com/search?q=Clark+Kent" target="_blank" style="color:#0077c0;">Clark Kent</a>',
        start: getDate(-24 * 2),
        duration: 2 * 24 * 60 * 60 * 1000,
        percent: 50,
        type: 'project',
      },
      {
        id: 22,
        label: 'Group subtask 2',
        user: '<a href="https://www.google.com/search?q=Clark+Kent" target="_blank" style="color:#0077c0;">Clark Kent</a>',
        start: getDate(24 * 2),
        duration: 2 * 24 * 60 * 60 * 1000,
        percent: 50,
        type: 'task',
      },
    ],
  },
```